### PR TITLE
Adjusted to support CHIP built-in SPI.

### DIFF
--- a/gaugette/spi.py
+++ b/gaugette/spi.py
@@ -27,5 +27,12 @@ class SPI:
             self.spi = Adafruit_BBIO.SPI.SPI(bus, device)
             self.writebytes = self.spi.writebytes
 
+	elif gaugette.platform.isCHIP:
+            import spidev
+            import spidev
+            self.spi = spidev.SpiDev()
+            self.spi.open(bus, device)
+            self.writebytes = self.spi.writebytes
+
         else:
             raise NotImplementedError("This platform is not supported.")

--- a/gaugette/ssd1306.py
+++ b/gaugette/ssd1306.py
@@ -139,13 +139,20 @@ class SSD1306:
         self.gpio.output(self.dc_pin, self.gpio.HIGH)
         #  chunk data to work around 255 byte limitation in adafruit implementation of writebytes
         # revisit - change to 1024 when Adafruit_BBIO is fixed.
-        max_xfer = 255 if gaugette.platform.isBeagleBoneBlack else 1024
+
+	max_xfer = 1024
+	if gaugette.platform.isBeagleBoneBlack:
+	    max_xfer = 255
+	elif gaugette.platform.isCHIP:
+	    max_xfer = 64
+
+        #max_xfer = 255 if (gaugette.platform.isBeagleBoneBlack or gaugette.platform.isCHIP) else 1024
         start = 0
         remaining = len(bytes)
         while remaining>0:
             count = remaining if remaining <= max_xfer else max_xfer
             remaining -= count
-            self.spi.writebytes(bytes[start:start+count])
+	    self.spi.writebytes(bytes[start:start+count])
             start += count
         self.gpio.output(self.dc_pin, self.gpio.LOW)
         


### PR DESCRIPTION
 Testing revealed support for only 64 byte chunks.
